### PR TITLE
フォームのチャットメンバーをリスト表示させる

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -27,6 +27,13 @@
           %input{name: "group[user_ids][]", type: "hidden", value: "#{current_user.id}"}
           %p.chat-group-user__name
             = current_user.name
+        - group.users.each do |user|
+          - unless user.id == current_user.id
+            .chat-group-user.clearfix.js-chat-member{id: "chat-group-user-#{user.id}"}
+              = f.hidden_field :'users', name: 'group[user_ids][]', value: user.id
+              %p.chat-group-user__name= user.name
+              .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right


### PR DESCRIPTION
#WHAT
フォームのチャットメンバーをリスト表示させる
#WHY
グループ編集フォームでは既存のメンバーを表示させ、削除することを可能にするため