### PR TITLE
時間表示を日本時間に変更

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -28,5 +28,6 @@ class MessagesController < ApplicationController
 
   def set_group
     @group = Group.find(params[:group_id])
+    Time.zone ='Tokyo'
   end
 end


### PR DESCRIPTION
#WHAT
時間表示を日本時間に変更
#WHY
メッセージ投稿時間がずれているため日本時間に直す必要があったため
